### PR TITLE
Update set-output to use the new environment files

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat .nvmrc)"
+        run: echo "name=NVMRC::$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
 
       - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat .nvmrc)"
+        run: echo "name=NVMRC::$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
 
       - name: Setup Node


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/